### PR TITLE
fix: line, column data

### DIFF
--- a/src/components/ContentSection/MainEditor.tsx
+++ b/src/components/ContentSection/MainEditor.tsx
@@ -1,7 +1,8 @@
 import ReactMarkdown from "react-markdown";
-import { useNoteDetailsStore } from "../../store/NoteStore";
 
+import { useNoteDetailsStore } from "../../store/NoteStore";
 import { useSettingsStore } from "../../store/SettingsStore";
+import { useUiStore } from "../../store/UiStore";
 
 import { getLineAndColumn } from "../../utils/StatsUtils";
 
@@ -15,6 +16,7 @@ const MainEditor: React.FC<MainEditorProps> = (props) => {
     (state) => state.appSettings.editorStyle
   );
   const { setLineAndColumn } = useNoteDetailsStore();
+  const { setEditorActive } = useUiStore();
 
   const updateLineAndColumn = (
     e:
@@ -33,6 +35,8 @@ const MainEditor: React.FC<MainEditorProps> = (props) => {
           onChange={(e) => props.setContents(e.target.value)}
           onKeyUp={(e) => updateLineAndColumn(e)}
           onMouseUp={(e) => updateLineAndColumn(e)}
+          onFocus={() => setEditorActive(true)}
+          onBlur={() => setEditorActive(false)}
           spellCheck={false}
           value={props.contents}
         />

--- a/src/components/ContentSection/NoteUtils/NoteDetails.tsx
+++ b/src/components/ContentSection/NoteUtils/NoteDetails.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 
-import { useNoteDetailsStore } from "../../../store/NoteStore";
+import {
+  useActiveNoteStore,
+  useNoteDetailsStore,
+} from "../../../store/NoteStore";
+import { useUiStore } from "../../../store/UiStore";
 
 type NoteDetailsProps = {
   contents: string;
@@ -8,6 +12,8 @@ type NoteDetailsProps = {
 
 const NoteDetails: React.FC<NoteDetailsProps> = (props) => {
   const { column, line } = useNoteDetailsStore();
+  const content = useActiveNoteStore((state) => state.activeNote.content);
+  const { editorActive } = useUiStore();
 
   const [wordCount, setWordCount] = useState<number>(0);
   const [charCount, setCharCount] = useState<number>(0);
@@ -30,7 +36,12 @@ const NoteDetails: React.FC<NoteDetailsProps> = (props) => {
 
   return (
     <span className="absolute right-3 bottom-3 text-xs text-muted-foreground">
-      Ln {line} Col {column} | Words {wordCount} Chars {charCount}
+      {editorActive && (
+        <>
+          Ln {line} Col {column} |{" "}
+        </>
+      )}
+      Words {wordCount} Chars {charCount}
     </span>
   );
 };

--- a/src/store/UiStore.ts
+++ b/src/store/UiStore.ts
@@ -1,11 +1,15 @@
 import { create } from "zustand";
 
-interface UiState {
+type UiStoreProps = {
   focusMode: boolean;
+  editorActive: boolean;
   setFocusMode: () => void;
-}
+  setEditorActive: (status: boolean) => void;
+};
 
-export const useUiStore = create<UiState>()((set) => ({
+export const useUiStore = create<UiStoreProps>()((set) => ({
   focusMode: true,
+  editorActive: false,
   setFocusMode: () => set((state) => ({ focusMode: !state.focusMode })),
+  setEditorActive: (status) => set((state) => ({ editorActive: status })),
 }));


### PR DESCRIPTION
If editor is not in focus, line and column data will not be show. Previously if certain notes have no content, or no note is selected, line and column of last active note was shown